### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: rust
+
+# Require Trusty as libssl2 crate requires cmake >= 2.8.11
+sudo: required
+dist: trusty
+
+rust:
+  - beta
+  - nightly
+  - stable
+
+matrix:
+  allow_failures:
+    - rust: nightly

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 snowpatch - CI for patches
 ==========================
 
+[![Build Status](https://travis-ci.org/ruscur/snowpatch.svg?branch=master)](https://travis-ci.org/ruscur/snowpatch)
 
 Overview
 -------


### PR DESCRIPTION
Here is a simple Travis CI configuration that builds snowpatch.

It passes:

 https://travis-ci.org/shenki/snowpatch/jobs/120391909

as does `cargo test`, but there are no unit tests.

We have to run the builds on Trusty as Cmake is horrible, and the libssl2 crate won't build with the version of Cmake present on Precise.